### PR TITLE
replace xslt-config with pkg-config

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,7 @@ delete $config{NO_THREADS};
 my $HAVE_USER_DEFINED = (defined($config{LIBS}) or defined($config{INC}) );
 
 unless ( $::is_Win32 ) { # cannot get config in W32
-    my $xsltcfg = "xslt-config";
+    my $xsltcfg = "pkg-config libxslt";
     my $libprefix = $ENV{XSLTPREFIX} || $config{XSLTPREFIX};
 
     delete $config{XSLTPREFIX}; # delete if exists, otherwise MakeMaker gets confused
@@ -57,8 +57,8 @@ unless ( $::is_Win32 ) { # cannot get config in W32
     if ( ! $HAVE_USER_DEFINED ) {
         # get libs and inc from gnome-config
         eval {
-            print "running xslt-config... ";
-            my $ver = backtick("$xsltcfg --version");
+            print "running $xsltcfg... ";
+            my $ver = backtick("$xsltcfg --modversion");
             my ($major, $minor, $point) = $ver =~ /(\d+)\.(\d+)\.(\d+)/g;
             if (not
                 (


### PR DESCRIPTION

In Debian we are currently applying the following patch to
XML-LibXSLT.
We thought you might be interested in it too.

    Description: replace xslt-config with pkg-config
     The former is going away.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/948963
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2020-01-15
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libxml-libxslt-perl/raw/master/debian/patches/no_more_xslt-config.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
