### PR TITLE
Avoid C implicit function declaration in Makefile.PL (C99 compat)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -463,10 +463,11 @@ SRC
             }
         }
         else {
-
+	    # Use a fake prototype in the style of autoconf.
             $result = try_link(<<"SRC", $libs);
-blank() { return 0; }
-int t() { ${func}(); return 0; }
+char blank(void) { return 0; }
+char ${func}(void);
+int t(void) { ${func}(); return 0; }
 SRC
         }
     }


### PR DESCRIPTION
Future compilers are likely not to support implicit function declarations.  Add a fake prototype so that the probes will not always fail with such compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
